### PR TITLE
upgrade cartesia-js and add continue: true to initial tts call

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@cartesia/cartesia-js": "2.1.2",
+        "@cartesia/cartesia-js": "^2.1.3",
         "pino": "^9.6.0",
         "pino-pretty": "^13.0.0"
       },
@@ -23,9 +23,9 @@
       }
     },
     "node_modules/@cartesia/cartesia-js": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@cartesia/cartesia-js/-/cartesia-js-2.1.2.tgz",
-      "integrity": "sha512-jifuGsTUb2pbQ5eDDIwCNo8x6iIohv7Y7fYeQJwEFHHHagKLWro6DLAdSz6PTBF5Ripcb0mABcwAXZ3ZkmoLyA==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@cartesia/cartesia-js/-/cartesia-js-2.1.3.tgz",
+      "integrity": "sha512-isoqDu3osFROMO6pipGCl9UfmDZv24LrlFpz5ZrnxB6g9rYuMIdWFd+lKP60cf1X9OE/udsJQTqm2ZRnaCsSTg==",
       "dependencies": {
         "emittery": "^0.13.1",
         "form-data": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@cartesia/cartesia-js": "2.1.2",
+    "@cartesia/cartesia-js": "^2.1.3",
     "pino": "^9.6.0",
     "pino-pretty": "^13.0.0"
   },

--- a/src/liveCartesiaClient.test.ts
+++ b/src/liveCartesiaClient.test.ts
@@ -63,5 +63,6 @@ describe("LiveCartesiaClient", () => {
     assert.ok(fs.existsSync(outputFile));
     const stats = fs.statSync(outputFile);
     assert.ok(stats.size > 0);
-  });
+  // sometimes streaming all the audio takes longer than the default timeout
+  }, { timeout: 30_000 });
 });

--- a/src/liveCartesiaClient.ts
+++ b/src/liveCartesiaClient.ts
@@ -102,6 +102,7 @@ export class LiveCartesiaClient {
           ...streamingOptions,
           contextId,
           transcript: firstChunk,
+          continue: true,
         });
         sentFirstChunk = true;
         responseFuture.resolve(response);


### PR DESCRIPTION
Hi Gleb, thanks for this excellent repro repo re: continuations.

I've fixed this with two changes:
1. upgrade the Cartesia SDK to 2.1.3, which contains a bugfix for continuations
2. add `continue: true` to the first tts request. (I'm open to suggestions for improving the docs here.)

Seems to work for me now. Let me know if this fixes the issue in your app, too.